### PR TITLE
Methods with generic return type and annotation

### DIFF
--- a/src/grammar/parser.y
+++ b/src/grammar/parser.y
@@ -429,11 +429,24 @@ MethodHeader: TypeParameters Type /* =Result */ IDENTIFIER
                 mth.setTypeParams(typeParams);
                 mth.setReturnType($2);
                 mth.setName($3);
-              } 
+              }
               PARENOPEN FormalParameterList_opt PARENCLOSE Dims_opt Throws_opt
               {
                 mth.setDimensions($8);
-              } 
+              }
+            | TypeParameters Annotation Type /* =Result */ IDENTIFIER
+              {
+                builder.beginMethod();
+                mth.setLineNumber(lexer.getLine());
+                mth.getModifiers().addAll(modifiers); modifiers.clear();
+                mth.setTypeParams(typeParams);
+                mth.setReturnType($3);
+                mth.setName($4);
+              }
+              PARENOPEN FormalParameterList_opt PARENCLOSE Dims_opt Throws_opt
+              {
+                mth.setDimensions($9);
+              }
             | Type /* =Result */ IDENTIFIER  
               {
                 builder.beginMethod();

--- a/src/test/java/com/thoughtworks/qdox/parser/ParserTest.java
+++ b/src/test/java/com/thoughtworks/qdox/parser/ParserTest.java
@@ -1167,6 +1167,52 @@ public class ParserTest extends TestCase {
         Assert.assertArrayEquals( new String[] { "final", "volatile" }, parameterCaptor.getValue().getModifiers().toArray( new String[0] ) );
         assertEquals( new TypeDef("int"), parameterCaptor.getValue().getType() );
     }
+    
+    public void testMethodWithAnnotatedGenericReturnValue() throws Exception {
+    	
+        setupLex(Parser.CLASS);
+        setupLex(Parser.IDENTIFIER, "MyClass");
+        setupLex(Parser.BRACEOPEN);
+        
+        setupLex(Parser.PUBLIC);
+        setupLex(Parser.LESSTHAN);
+        setupLex(Parser.IDENTIFIER, "T");
+        setupLex(Parser.GREATERTHAN);
+        setupLex(Parser.AT);
+        setupLex(Parser.IDENTIFIER, "Nullable");
+        setupLex(Parser.IDENTIFIER, "T");
+        setupLex(Parser.IDENTIFIER, "doSomething");
+        setupLex(Parser.PARENOPEN);
+        setupLex(Parser.PARENCLOSE);
+        setupLex(Parser.CODEBLOCK);
+
+        setupLex(Parser.BRACECLOSE);
+        setupLex(0);
+        
+    	Parser parser = new Parser(lexer, builder);
+    	parser.parse();
+        
+        ArgumentCaptor<ClassDef> classCaptor = ArgumentCaptor.forClass(ClassDef.class);
+        ArgumentCaptor<MethodDef> methodCaptor = ArgumentCaptor.forClass(MethodDef.class);
+        ArgumentCaptor<AnnoDef> annotationCaptor = ArgumentCaptor.forClass(AnnoDef.class);
+
+        verify(builder).beginClass(classCaptor.capture());
+        verify(builder).beginMethod();
+        verify(builder).endMethod(methodCaptor.capture());
+        verify(builder).addAnnotation(annotationCaptor.capture());
+        verify(builder).endClass();
+
+        ClassDef cls = classCaptor.getValue();
+        assertEquals("MyClass", cls.getName());
+
+        MethodDef mth = methodCaptor.getValue();
+        assertTrue(mth.getModifiers().contains("public"));
+        assertEquals(new TypeDef("T"), mth.getReturnType());
+        assertEquals("doSomething", mth.getName());
+        
+        AnnoDef annotation = annotationCaptor.getValue();
+        assertEquals("Nullable", annotation.getTypeDef().getName());
+    }
 
     public void testMethodThrowingOneException() throws Exception {
 


### PR DESCRIPTION
I'm using the null pointer analysis feature in the Eclipse compiler which allowichs to annotate parameters and method return values. Our source scanner which is based on qdox fails to parse certain methods, though. It turns out that Methods that define a return type and an annotation on the return type fail to parse. 

This changeset  adds support for this type of methods.
