### PR TITLE
Support annotations on type parameter declarations

### DIFF
--- a/src/grammar/parser.y
+++ b/src/grammar/parser.y
@@ -1454,7 +1454,7 @@ ReferenceType: ArrayType
 // InterfaceType:
 //     ClassType 
 // TypeVariable:
-//     {Annotation} Identifier 
+//     {Annotation} Identifier // already covered by ClassType
 
 // ArrayType:
 //     PrimitiveType Dims 

--- a/src/grammar/parser.y
+++ b/src/grammar/parser.y
@@ -1665,11 +1665,21 @@ ClassOrInterfaceType: TypeDeclSpecifier
 // Actually
 // TypeDeclSpecifier: TypeName | ClassOrInterfaceType . Identifier
 // TypeName:          Identifier | TypeName . Identifier
-TypeDeclSpecifier: QualifiedIdentifier
-                 | ClassOrInterfaceType DOT IDENTIFIER 
-                   { 
+TypeDeclSpecifier:
+                 IDENTIFIER
+                 | Annotations_opt IDENTIFIER
+                   {
+                     $$ = $2;
+                   }
+                 | ClassOrInterfaceType DOT IDENTIFIER
+                   {
                      $$ = $1.getName() + '.' + $3;
-                   };
+                   }
+                 | ClassOrInterfaceType DOT Annotations_opt IDENTIFIER
+                   {
+                     $$ = $1.getName() + '.' + $4;
+                   }
+                   ;
 
 
 

--- a/src/test/java/com/thoughtworks/qdox/GenericsTest.java
+++ b/src/test/java/com/thoughtworks/qdox/GenericsTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 import java.io.StringReader;
 import java.util.Collections;
 
+import com.thoughtworks.qdox.model.impl.DefaultJavaParameterizedType;
 import junit.framework.TestCase;
 
 import com.thoughtworks.qdox.model.JavaClass;
@@ -139,7 +140,25 @@ public class GenericsTest extends TestCase {
         builder.addSource(new StringReader(source));
         assertEquals("Bar", builder.getClassByName("Bar").getName());
     }
-    
+
+    public void testShouldUnderstandAnnotationsOnTypeParameters() {
+        String source = "" +
+                "public class Bar {" +
+                "    public static Collection<String> foo() { }" +
+                "    public static Collection<java.lang.String> foo2() { }" +
+                "    public static Collection<@Annot String> foo3() { }" +
+                "    public static Collection<java.lang.@Annot String> foo4() { }" +
+                "}";
+        builder.addSource(new StringReader(source));
+        JavaClass bar = builder.getClassByName("Bar");
+        assertEquals("Bar", bar.getName());
+
+        assertEquals(builder.getClassByName("java.lang.String"), (( (DefaultJavaParameterizedType)bar.getMethods().get(0).getReturns()).getActualTypeArguments().get(0)));
+        assertEquals(builder.getClassByName("java.lang.String"), (( (DefaultJavaParameterizedType)bar.getMethods().get(1).getReturns()).getActualTypeArguments().get(0)));
+        assertEquals(builder.getClassByName("java.lang.String"), (( (DefaultJavaParameterizedType)bar.getMethods().get(2).getReturns()).getActualTypeArguments().get(0)));
+        assertEquals(builder.getClassByName("java.lang.String"), (( (DefaultJavaParameterizedType)bar.getMethods().get(3).getReturns()).getActualTypeArguments().get(0)));
+    }
+
     public void testGenericField() {
         // Also see QDOX-77
         String source = "" +


### PR DESCRIPTION
QDox can't parse source code that uses annotations on type parameter declarations (e.g. `List<@NotEmpty String>`). This fixes that.