### PR TITLE
fix NPE on primitive getSuperClass

### DIFF
--- a/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaClass.java
+++ b/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaClass.java
@@ -143,6 +143,11 @@ public class DefaultJavaClass
     public JavaType getSuperClass()
     {
         JavaType result = null;
+
+        if(isPrimitive()) {
+            return null;
+        }
+
         JavaClass OBJECT_JAVACLASS = getJavaClassLibrary().getJavaClass( "java.lang.Object" );
         JavaClass ENUM_JAVACLASS = getJavaClassLibrary().getJavaClass( "java.lang.Enum" );
 

--- a/src/test/java/com/thoughtworks/qdox/ClassResolutionTest.java
+++ b/src/test/java/com/thoughtworks/qdox/ClassResolutionTest.java
@@ -90,4 +90,14 @@ public class ClassResolutionTest
         assertEquals( "some.pack.Test.Inner.Inner2", parameter.getType().getFullyQualifiedName() );
         assertEquals( "some.pack.Test.Inner.Inner2", parameter.getFullyQualifiedName() );
     }
+
+    public void testIsAWithPrimitives()
+    {
+        JavaProjectBuilder builder = new JavaProjectBuilder();
+        String source = "class Foo { public byte[] bar() { return null; } }";
+        builder.addSource( new StringReader( source ) );
+        JavaMethod method = builder.getClassByName("Foo").getMethods().get(0);
+        JavaClass returns = method.getReturns();
+        assertFalse(returns.isA(builder.getClassByName("java.lang.Object")));
+    }
 }


### PR DESCRIPTION
While trying to upgrade qdox we found a regression where `isA(...)` throws an NPE if the target is a primitive type. That's because in JavaType where the JavaClass is instantiated no Source is provided for primitive types, which causes getJavaClassLibrary() to throw the NPE. This works around that.