### PR TITLE
Add getUpperBounds getLowerBounds in JavaWildcardType

### DIFF
--- a/src/main/java/com/thoughtworks/qdox/model/JavaWildcardType.java
+++ b/src/main/java/com/thoughtworks/qdox/model/JavaWildcardType.java
@@ -19,9 +19,17 @@ package com.thoughtworks.qdox.model;
  * under the License.
  */
 
+import com.thoughtworks.qdox.model.impl.DefaultJavaWildcardType;
+
+import java.util.List;
+
 /**
  * Equivalent of {@link java.lang.reflect.WildcardType}
  */
 public interface JavaWildcardType extends JavaType
 {
+    JavaType[] getUpperBounds();
+
+    JavaType[] getLowerBounds();
+
 }

--- a/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaWildcardType.java
+++ b/src/main/java/com/thoughtworks/qdox/model/impl/DefaultJavaWildcardType.java
@@ -29,16 +29,17 @@ import com.thoughtworks.qdox.model.JavaWildcardType;
  * Equivalent of {@link java.lang.reflect.WildcardType}
  * This class supports both the 'super' and 'extends' wildcards. For &lt;?&gt; you must use the normal Type, because ?
  * itself can't be generic
- * 
+ *
  * @author Robert Scholte
  */
 public class DefaultJavaWildcardType extends DefaultJavaType
-    implements JavaWildcardType
+        implements JavaWildcardType
 {
-    public static enum BoundType { EXTENDS, SUPER }
-    
+    public static enum BoundType
+    {EXTENDS, SUPER}
+
     private BoundType boundType;
-    
+
     private List<JavaType> bounds;
 
     public DefaultJavaWildcardType()
@@ -46,7 +47,7 @@ public class DefaultJavaWildcardType extends DefaultJavaType
         super( "?" );
         bounds = Collections.emptyList();
     }
-    
+
     public DefaultJavaWildcardType( JavaType type, BoundType boundType )
     {
         this();
@@ -55,10 +56,37 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     }
 
     @Override
+    public JavaType[] getUpperBounds()
+    {
+        switch (boundType)
+        {
+            case SUPER:
+                return new JavaType[] { new DefaultJavaClass("java.lang.Object") };
+            case EXTENDS:
+                return bounds.toArray(new JavaType[]{});
+            default:
+                return new JavaType[0];
+        }
+    }
+
+    @Override
+    public JavaType[] getLowerBounds()
+    {
+        switch (boundType)
+        {
+            case SUPER:
+                return bounds.toArray(new JavaType[]{});
+            case EXTENDS:
+            default:
+                return new JavaType[0];
+        }
+    }
+
+    @Override
     public String getFullyQualifiedName()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getFullyQualifiedName() );
         }
@@ -69,7 +97,7 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     public String getGenericValue()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getGenericValue() );
         }
@@ -80,18 +108,18 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     public String getGenericFullyQualifiedName()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getGenericFullyQualifiedName() );
         }
         return builder.toString();
     }
-    
+
     @Override
     public String getCanonicalName()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getCanonicalName() );
         }
@@ -102,7 +130,7 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     public String getGenericCanonicalName()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getGenericCanonicalName() );
         }
@@ -113,7 +141,7 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     public String getValue()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.getValue() );
         }
@@ -125,21 +153,20 @@ public class DefaultJavaWildcardType extends DefaultJavaType
     public String toGenericString()
     {
         StringBuilder builder = getPreparedStringBuilder();
-        for( JavaType type : bounds )
+        for ( JavaType type : bounds )
         {
             builder.append( type.toGenericString() );
         }
         return builder.toString();
     }
-    
+
     private StringBuilder getPreparedStringBuilder()
     {
         StringBuilder builder = new StringBuilder( "?" );
-        if( BoundType.EXTENDS.equals( boundType ) )
+        if ( BoundType.EXTENDS.equals( boundType ) )
         {
             builder.append( " extends " );
-        }
-        else if( BoundType.SUPER.equals( boundType ) )
+        } else if ( BoundType.SUPER.equals( boundType ) )
         {
             builder.append( " super " );
         }

--- a/src/test/java/com/thoughtworks/qdox/model/JavaWildcardTypeTest.java
+++ b/src/test/java/com/thoughtworks/qdox/model/JavaWildcardTypeTest.java
@@ -1,0 +1,51 @@
+package com.thoughtworks.qdox.model;
+
+import com.thoughtworks.qdox.library.ClassLibrary;
+import com.thoughtworks.qdox.library.SortedClassLibraryBuilder;
+import com.thoughtworks.qdox.model.impl.DefaultJavaType;
+import com.thoughtworks.qdox.model.impl.DefaultJavaWildcardType;
+import com.thoughtworks.qdox.type.TypeResolver;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class JavaWildcardTypeTest<T extends JavaWildcardType>
+{
+    private TypeResolver typeResolver;
+
+    @Before
+    public void setUp() {
+        ClassLibrary classLibrary = new SortedClassLibraryBuilder().appendDefaultClassLoaders().getClassLibrary();
+        List<String> typeList = new ArrayList<String>();
+        typeList.add("java.lang.*");
+        typeList.add("java.util.*");
+        typeResolver = TypeResolver.byClassName( "Object", classLibrary, typeList );
+    }
+
+    public abstract T newWildcardType();
+
+    public abstract T newWildcardType( String fullname, TypeResolver typeResolver, DefaultJavaWildcardType.BoundType boundType );
+
+    @Test
+    public void testGetLowerBounds() throws NoSuchFieldException
+    {
+        T wildcardType = newWildcardType( "java.util.List", typeResolver, DefaultJavaWildcardType.BoundType.SUPER );
+        assertEquals( "java.lang.Object", wildcardType.getUpperBounds()[0].getFullyQualifiedName() );
+        assertEquals( "java.util.List", wildcardType.getLowerBounds()[0].getFullyQualifiedName() );
+    }
+
+    @Test
+    public void testGetUpperBounds() throws NoSuchFieldException
+    {
+        T wildcardType = newWildcardType( "java.util.List", typeResolver, DefaultJavaWildcardType.BoundType.EXTENDS );
+        assertEquals( "java.util.List", wildcardType.getUpperBounds()[0].getFullyQualifiedName() );
+        assertEquals( 0, wildcardType.getLowerBounds().length );
+    }
+
+}

--- a/src/test/java/com/thoughtworks/qdox/model/impl/DefaultJavaWildcardTypeTest.java
+++ b/src/test/java/com/thoughtworks/qdox/model/impl/DefaultJavaWildcardTypeTest.java
@@ -1,0 +1,21 @@
+package com.thoughtworks.qdox.model.impl;
+
+
+import com.thoughtworks.qdox.model.JavaWildcardTypeTest;
+import com.thoughtworks.qdox.type.TypeResolver;
+
+public class DefaultJavaWildcardTypeTest extends JavaWildcardTypeTest<DefaultJavaWildcardType>
+{
+    @Override
+    public DefaultJavaWildcardType newWildcardType()
+    {
+        return new DefaultJavaWildcardType();
+    }
+
+    @Override
+    public DefaultJavaWildcardType newWildcardType( String fullname, TypeResolver typeResolver, DefaultJavaWildcardType.BoundType boundType )
+    {
+        DefaultJavaType defaultJavaType = new DefaultJavaType( fullname, typeResolver );
+        return new DefaultJavaWildcardType( defaultJavaType, boundType );
+    }
+}


### PR DESCRIPTION
Hello, I need to parse some code like 
`
List<? extends String> test = new ArrayList<>();
`
the field bounds of DefaultJavaWildcardType is important for me to process the type information.

I'm currently using reflect to get the information
```
Field bounds = DefaultJavaWildcardType.class.getDeclaredField( "bounds" );
bounds.setAccessible( true );
bounds.get( wildcardType );
```
It's really complex, so I added the get method to it.