### PR TITLE
Fix the bug that does not allow the use of permits as field names.

### DIFF
--- a/src/grammar/lexer.flex
+++ b/src/grammar/lexer.flex
@@ -267,7 +267,6 @@ JavadocEnd                      = "*"+ "/"
     "new"               { return Parser.NEW; }
     "sealed"            { return Parser.SEALED; }
     "non-sealed"        { return Parser.NON_SEALED; }
-    "permits"           { return Parser.PERMITS; }
 
     "["                 { nestingDepth++; return Parser.SQUAREOPEN; }
     "]"                 { nestingDepth--; return Parser.SQUARECLOSE; }
@@ -315,6 +314,13 @@ JavadocEnd                      = "*"+ "/"
         pushState(NAME);
         return Parser.RECORD;
     }
+    "permits" / {WhiteSpace}+ {Id} {
+        markAnnotatedElementLine();
+        classDepth++;
+        braceMode = TYPE;
+        pushState(NAME);
+        return Parser.PERMITS;
+     }
     "@"                 {
         markAnnotatedElementLine();
         pushState(ATANNOTATION);

--- a/src/test/java/com/thoughtworks/qdox/PermitsTest.java
+++ b/src/test/java/com/thoughtworks/qdox/PermitsTest.java
@@ -1,0 +1,35 @@
+package com.thoughtworks.qdox;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+/**
+ *
+ * @author shalousun
+ */
+public class PermitsTest {
+    @Test
+    public void permitsAsTypeAndIdentifiers() {
+        String source = "public class MyPermits {\n" +
+                "\n" +
+                "    private Object permits;\n" +
+                "\n" +
+                "    public MyPermits(){}\n" +
+                "\n" +
+                "    public MyPermits(Object permits) {\n" +
+                "        this.permits = permits;\n" +
+                "    }\n" +
+                "\n" +
+                "    public Object getPermits() {\n" +
+                "        return permits;\n" +
+                "    }\n" +
+                "\n" +
+                "    public void setPermits(Object permits) {\n" +
+                "        this.permits = permits;\n" +
+                "    }\n" +
+                "}";
+        JavaProjectBuilder javaDocBuilder = new JavaProjectBuilder();
+        javaDocBuilder.addSource( new StringReader(source) );
+    }
+}


### PR DESCRIPTION
Fix the bug that does not allow the use of permits as field names.
```
public class MyPermits {

    private Object permits;

    public MyPermits(){}

    public MyPermits(Object permits) {
        this.permits = permits;
    }

    public Object getPermits() {
        return permits;
    }

    public void setPermits(Object permits) {
        this.permits = permits;
    }
}

```