### PR TITLE
Sonatype Central Portal publishing

### DIFF
--- a/.github/release-settings.xml
+++ b/.github/release-settings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+
+<!--
+  Merge these into your own ~/.m2/settings.xml
+
+  Don't forget to fill in the username/password!
+
+  If you want to publish snapshots to Sonatype Central Portal, don't forget to enable snapshots on NS!
+-->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <pluginGroups>
+    <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
+  </pluginGroups>
+
+  <servers>
+    <server>
+      <id>sonatype-central-portal</id>
+      <username>${env.MAVEN_USER}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
+      <configuration>
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+        <njord.snapshotUrl>njord:template:snapshot-sca</njord.snapshotUrl>
+      </configuration>
+    </server>
+  </servers>
+
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -123,22 +123,35 @@
     <qdox.javaparser.stack>500</qdox.javaparser.stack>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <version.njord>0.8.4</version.njord>
   </properties>
 
   <distributionManagement>
     <snapshotRepository>
-      <id>central</id>
-      <url>https://central.sonatype.com/api/v1/publisher</url>
+      <id>sonatype-central-portal</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>central</id>
-      <url>https://central.sonatype.com/api/v1/publisher</url>
+      <id>sonatype-central-portal</id>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </distributionManagement>
   
   <build>
+    <extensions>
+      <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension3</artifactId>
+        <version>${version.njord}</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>eu.maveniverse.maven.plugins</groupId>
+          <artifactId>njord</artifactId>
+          <version>${version.njord}</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
@@ -431,16 +444,6 @@
             </goals>
           </execution>
         </executions -->
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <publishingServerId>central</publishingServerId>
-          <autoPublish>true</autoPublish>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
POM changes and example settings in `.github/release-settings.xml` as "template" to merge into your settings.

To check publishing status: `mvn njord:status -s .github/release-settings.xml`

Omit the `-s` once you **merged and set up your own settings**.

Docs: https://maveniverse.eu/docs/njord/migration/

To release :
* release as usual, but it will locally stage (as `qdox-NNNN`)
* manually invoke `mvn njord:publish`
* or you can use user property during release `-Dnjord.autoPublish` and just follow instructions

The goal of Njord is to not meddle with your build, does not rewrite model, does not replace plugins and work transparently with mvn3 and mvn4 (model in mvn4 is immutable).